### PR TITLE
Fixed bug in data migration script

### DIFF
--- a/file-1730742672982.txt
+++ b/file-1730742672982.txt
@@ -1,0 +1,1 @@
+const flattenObject = (obj, prefix = ‘’) => { return Object.keys(obj).reduce((acc, k) => { const pre = prefix.length ? prefix + ‘.’ : ‘’; if (typeof obj[k] === ‘object’ && obj[k] !== null && !Array.isArray(obj[k])) { Object.assign(acc, flattenObject(obj[k], pre + k)); } else { acc[pre + k] = obj[k]; } return acc; }, {}); };


### PR DESCRIPTION
const flattenObject = (obj, prefix = ‘’) => { return Object.keys(obj).reduce((acc, k) => { const pre = prefix.length ? prefix + ‘.’ : ‘’; if (typeof obj[k] === ‘object’ && obj[k] !== null && !Array.isArray(obj[k])) { Object.assign(acc, flattenObject(obj[k], pre + k)); } else { acc[pre + k] = obj[k]; } return acc; }, {}); };